### PR TITLE
Fix mobile UX: focus mode exit, bookmarks, fullscreen, TTS language, defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
       </div>
       <!-- Live WPM Counter -->
       <div id="live-wpm-badge" class="hidden" aria-hidden="true">
-        <span id="live-wpm-value">300</span>
+        <span id="live-wpm-value">700</span>
         <span class="live-wpm-unit">WPM</span>
       </div>
     </div>
@@ -226,8 +226,8 @@
     <div class="ctrl-group" id="group-speed">
       <label class="group-label" for="slider-wpm">Speed</label>
       <div class="slider-row">
-        <input type="range" id="slider-wpm" min="100" max="1500" step="10" value="300" />
-        <span class="slider-readout"><span id="wpm-display">300</span> WPM</span>
+        <input type="range" id="slider-wpm" min="100" max="1500" step="10" value="700" />
+        <span class="slider-readout"><span id="wpm-display">700</span> WPM</span>
       </div>
     </div>
 
@@ -321,10 +321,13 @@
   <div id="bookmarks-panel" class="side-panel hidden" role="complementary" aria-label="Bookmarks">
     <div class="panel-header">
       <span>🔖 Bookmarks</span>
-      <button class="panel-close">✕</button>
+      <div class="panel-header-actions">
+        <button id="btn-add-bookmark" class="toolbar-btn" title="Add bookmark at current word">+ Add</button>
+        <button class="panel-close">✕</button>
+      </div>
     </div>
     <div class="panel-body" id="bookmarks-list">
-      <p class="panel-empty">No bookmarks yet.<br>Press <kbd>B</kbd> while reading to add one.</p>
+      <p class="panel-empty">No bookmarks yet.<br>Press <kbd>B</kbd> or tap <strong>+ Add</strong> above.</p>
     </div>
   </div>
 
@@ -386,7 +389,7 @@
   </div>
 
   <!-- FOCUS HINT -->
-  <div id="focus-hint" class="hidden">Press <kbd>F</kbd> or <kbd>ESC</kbd> to exit focus mode</div>
+  <div id="focus-hint" class="hidden">Press <kbd>F</kbd> or <kbd>ESC</kbd> to exit focus mode · Double-tap on mobile</div>
 
   <!-- TOAST -->
   <div id="toast-container" aria-live="polite" aria-atomic="false"></div>

--- a/style.css
+++ b/style.css
@@ -439,6 +439,7 @@ button.secondary-btn:hover { background:var(--accent-hover); color:var(--btn-tex
 .side-panel { position:fixed; top:0; right:0; bottom:0; width:300px; background:var(--bg-app); border-left:1px solid var(--border); z-index:301; display:flex; flex-direction:column; box-shadow:-6px 0 24px var(--shadow); }
 .side-panel.hidden { display:none; }
 .panel-header { display:flex; align-items:center; justify-content:space-between; padding:12px 13px; border-bottom:1px solid var(--border); font-weight:600; font-size:14px; flex-shrink:0; }
+.panel-header-actions { display:flex; align-items:center; gap:6px; }
 .panel-close { background:none; border:none; color:var(--text-muted); font-size:15px; cursor:pointer; padding:2px 6px; border-radius:3px; line-height:1; }
 .panel-close:hover { background:var(--bg-panel); color:var(--text-default); border-color:transparent; }
 .panel-body { flex:1; overflow-y:auto; padding:10px; scrollbar-width:thin; }


### PR DESCRIPTION
- Add double-tap gesture to exit focus mode on mobile (no ESC key available)
- Use Fullscreen API when entering focus mode to hide address bar on mobile
- Sync focus state when user exits fullscreen via browser controls
- Add "+" Add button to bookmarks panel so mobile users can add bookmarks
  without keyboard shortcut (B key)
- Detect document language (Portuguese vs English) for TTS voice selection
  by sampling text for common Portuguese markers
- Re-pick TTS voice on file load to match detected language
- Set default WPM to 700 (from 300)
- Enable smart pace by default

https://claude.ai/code/session_011CbR5wXhDQvJaeRPE78N4f